### PR TITLE
make background color chromakey compatable.

### DIFF
--- a/graphics/style.css
+++ b/graphics/style.css
@@ -1,4 +1,4 @@
-html, body {margin:0;padding:0;height:100%; overflow: hidden;}
+html, body {margin:0;padding:0;height:100%; overflow: hidden;background-color: #00ff00;}
 
 
 .widgetcontainer {

--- a/graphics/style.css
+++ b/graphics/style.css
@@ -1,4 +1,4 @@
-html, body {margin:0;padding:0;height:100%; overflow: hidden;background-color: #00ff00;}
+html, body {margin:0;padding:0;height:100%; overflow: hidden;background-color: #ff00ff;}
 
 
 .widgetcontainer {


### PR DESCRIPTION
Set the background to chromakey magenta.  With white, the techlahoma logo can disappear completely, since current builds of obs-browser, and obs-linuxbrowser do not guarantee that the alpha values will be passed through. This uses a "guaranteed color" to prevent this.  This may need to be changed to avoid some crazy logos, but this should be close enough for now.